### PR TITLE
feat: run CI on PRs and auto-release on merge to main

### DIFF
--- a/.github/workflows/build-grammars.yml
+++ b/.github/workflows/build-grammars.yml
@@ -2,8 +2,10 @@ name: Build Grammars
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -43,10 +45,25 @@ jobs:
           echo "=== Release artifacts ==="
           ls -la dist/*.tar.gz dist/manifest.json 2>/dev/null || echo "No artifacts found"
 
+      - name: Generate version
+        id: version
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            # Auto-version for main branch: v1.0.YYYYMMDD.HHMMSS
+            VERSION="v1.0.$(date -u +%Y%m%d.%H%M%S)"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           files: |
             dist/*.tar.gz
             dist/manifest.json
@@ -54,8 +71,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifacts (for workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload artifacts (for PRs and workflow_dispatch)
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: grammars


### PR DESCRIPTION
## Summary

Update CI workflow to:

- **PRs**: Build and validate, upload artifacts (no release)
- **Push to main**: Build and create release with auto-version (`v1.0.YYYYMMDD.HHMMSS`)
- **Tag push**: Build and create release with tag version
- **workflow_dispatch**: Build and upload artifacts for testing

## Why

- Catch build failures before merge
- Automate releases on every merge to main

Closes #12