### PR TITLE
fix: add write permissions for release creation

### DIFF
--- a/.github/workflows/build-grammars.yml
+++ b/.github/workflows/build-grammars.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: macos-14  # Apple Silicon runner (can build universal)


### PR DESCRIPTION
## Summary

Add `permissions: contents: write` to the workflow to allow creating releases and tags.

## Why

The previous build failed with:
```
Resource not accessible by integration
```

The default `GITHUB_TOKEN` needs explicit write permissions for creating releases.