### PR TITLE
feat: add systems programming grammars

### DIFF
--- a/grammars.json
+++ b/grammars.json
@@ -120,6 +120,51 @@
       "version": "v1.1.1",
       "license": "MIT",
       "aliases": ["makefile"]
+    },
+    {
+      "name": "c",
+      "displayName": "C",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-c",
+      "version": "v0.24.1",
+      "license": "MIT",
+      "aliases": []
+    },
+    {
+      "name": "cpp",
+      "displayName": "C++",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-cpp",
+      "version": "v0.23.4",
+      "license": "MIT",
+      "aliases": ["cc", "cxx"]
+    },
+    {
+      "name": "rust",
+      "displayName": "Rust",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-rust",
+      "version": "v0.24.0",
+      "license": "MIT",
+      "aliases": ["rs"]
+    },
+    {
+      "name": "go",
+      "displayName": "Go",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-go",
+      "version": "v0.25.0",
+      "license": "MIT",
+      "aliases": ["golang"]
+    },
+    {
+      "name": "zig",
+      "displayName": "Zig",
+      "org": "tree-sitter-grammars",
+      "repo": "tree-sitter-zig",
+      "version": "v1.1.2",
+      "license": "MIT",
+      "aliases": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add C, C++, Rust, Go, and Zig grammars for systems programming language documentation.

### Grammars Added

| Language | Version | License | Aliases |
|----------|---------|---------|---------|
| C | v0.24.1 | MIT | - |
| C++ | v0.23.4 | MIT | cc, cxx |
| Rust | v0.24.0 | MIT | rs |
| Go | v0.25.0 | MIT | golang |
| Zig | v1.1.2 | MIT | - |

## Verification

- [x] All 18 grammars build successfully
- [x] Universal binaries verified
- [x] Queries included for all grammars

Closes #5