### PR TITLE
feat: add JVM and .NET grammars

### DIFF
--- a/grammars.json
+++ b/grammars.json
@@ -165,6 +165,42 @@
       "version": "v1.1.2",
       "license": "MIT",
       "aliases": []
+    },
+    {
+      "name": "java",
+      "displayName": "Java",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-java",
+      "version": "v0.23.5",
+      "license": "MIT",
+      "aliases": []
+    },
+    {
+      "name": "kotlin",
+      "displayName": "Kotlin",
+      "org": "tree-sitter-grammars",
+      "repo": "tree-sitter-kotlin",
+      "version": "v1.1.0",
+      "license": "MIT",
+      "aliases": ["kt"]
+    },
+    {
+      "name": "scala",
+      "displayName": "Scala",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-scala",
+      "version": "v0.24.0",
+      "license": "MIT",
+      "aliases": []
+    },
+    {
+      "name": "c_sharp",
+      "displayName": "C#",
+      "org": "tree-sitter",
+      "repo": "tree-sitter-c-sharp",
+      "version": "v0.23.1",
+      "license": "MIT",
+      "aliases": ["csharp", "cs"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add Java, Kotlin, Scala, and C# grammars for JVM and .NET platform documentation.

### Grammars Added

| Language | Version | License | Aliases | Notes |
|----------|---------|---------|---------|-------|
| Java | v0.23.5 | MIT | - | |
| Kotlin | v1.1.0 | MIT | kt | No highlight queries |
| Scala | v0.24.0 | MIT | - | |
| C# | v0.23.1 | MIT | csharp, cs | |

## Verification

- [x] All 22 grammars build successfully
- [x] Universal binaries verified
- [x] Queries included where available

Closes #6