### PR TITLE
docs: update README with new grammars and alphabetize table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,46 +34,49 @@ TSLanguage* (*tree_sitter_javascript)(void) = dlsym(handle, "tree_sitter_javascr
 TSLanguage* lang = tree_sitter_javascript();
 ```
 
-## Supported Languages (36)
+## Supported Languages (39)
 
 | Language | Repo | Version | License | Aliases |
 |----------|------|---------|---------|---------|
-| JavaScript | tree-sitter/tree-sitter-javascript | v0.23.1 | MIT | js, jsx, mjs, cjs |
-| Python | tree-sitter/tree-sitter-python | v0.23.6 | MIT | py |
-| HTML | tree-sitter/tree-sitter-html | v0.23.2 | MIT | htm |
-| CSS | tree-sitter/tree-sitter-css | v0.25.0 | MIT | |
-| JSON | tree-sitter/tree-sitter-json | v0.24.8 | MIT | |
-| TypeScript | tree-sitter/tree-sitter-typescript | v0.23.2 | MIT | ts |
-| TSX | tree-sitter/tree-sitter-typescript | v0.23.2 | MIT | |
-| YAML | tree-sitter-grammars/tree-sitter-yaml | v0.7.2 | MIT | yml |
-| XML | tree-sitter-grammars/tree-sitter-xml | v0.7.0 | MIT | |
-| Markdown | tree-sitter-grammars/tree-sitter-markdown | v0.5.2 | MIT | md |
-| Dockerfile | camdencheek/tree-sitter-dockerfile | v0.2.0 | MIT | |
-| HCL | tree-sitter-grammars/tree-sitter-hcl | v1.2.0 | Apache-2.0 | terraform, tf |
-| Makefile | tree-sitter-grammars/tree-sitter-make | v1.1.1 | MIT | make |
-| C | tree-sitter/tree-sitter-c | v0.24.1 | MIT | |
-| C++ | tree-sitter/tree-sitter-cpp | v0.23.4 | MIT | cc, cxx |
-| Rust | tree-sitter/tree-sitter-rust | v0.24.0 | MIT | rs |
-| Go | tree-sitter/tree-sitter-go | v0.25.0 | MIT | golang |
-| Zig | tree-sitter-grammars/tree-sitter-zig | v1.1.2 | MIT | |
-| Java | tree-sitter/tree-sitter-java | v0.23.5 | MIT | |
-| Kotlin | tree-sitter-grammars/tree-sitter-kotlin | v1.1.0 | MIT | kt |
-| Scala | tree-sitter/tree-sitter-scala | v0.24.0 | MIT | |
-| C# | tree-sitter/tree-sitter-c-sharp | v0.23.1 | MIT | csharp, cs |
-| Ruby | tree-sitter/tree-sitter-ruby | v0.23.1 | MIT | rb |
-| PHP | tree-sitter/tree-sitter-php | v0.24.2 | MIT | |
-| Lua | tree-sitter-grammars/tree-sitter-lua | v0.4.1 | MIT | |
 | Bash | tree-sitter/tree-sitter-bash | v0.25.1 | MIT | sh, shell, zsh |
-| Haskell | tree-sitter/tree-sitter-haskell | v0.23.1 | MIT | hs |
-| OCaml | tree-sitter/tree-sitter-ocaml | v0.24.2 | MIT | ml |
+| C | tree-sitter/tree-sitter-c | v0.24.1 | MIT | |
+| C# | tree-sitter/tree-sitter-c-sharp | v0.23.1 | MIT | csharp, cs |
+| C++ | tree-sitter/tree-sitter-cpp | v0.23.4 | MIT | cc, cxx |
+| Clojure | sogaiu/tree-sitter-clojure | v0.0.13 | CC0-1.0 | clj, cljs, cljc, bb |
+| Common Lisp | tree-sitter-grammars/tree-sitter-commonlisp | v0.4.1 | MIT | lisp, cl |
+| CSS | tree-sitter/tree-sitter-css | v0.25.0 | MIT | |
+| Diff | tree-sitter-grammars/tree-sitter-diff | v0.1.0 | MIT | patch |
+| Dockerfile | camdencheek/tree-sitter-dockerfile | v0.2.0 | MIT | |
 | Elixir | elixir-lang/tree-sitter-elixir | v0.3.4 | Apache-2.0 | ex, exs |
 | Erlang | WhatsApp/tree-sitter-erlang | 0.1.0 | Apache-2.0 | erl |
-| Gleam | gleam-lang/tree-sitter-gleam | v1.1.0 | Apache-2.0 | |
-| Common Lisp | tree-sitter-grammars/tree-sitter-commonlisp | v0.4.1 | MIT | lisp, cl |
-| Swift | alex-pinkus/tree-sitter-swift | 0.7.1 | MIT | |
-| R | r-lib/tree-sitter-r | v1.2.0 | MIT | |
+| Fortran | stadelmanma/tree-sitter-fortran | v0.5.1 | MIT | f90, f95, f03 |
 | GDScript | PrestonKnopp/tree-sitter-gdscript | v6.0.0 | MIT | gd |
-| Diff | tree-sitter-grammars/tree-sitter-diff | v0.1.0 | MIT | patch |
+| Gleam | gleam-lang/tree-sitter-gleam | v1.1.0 | Apache-2.0 | |
+| Go | tree-sitter/tree-sitter-go | v0.25.0 | MIT | golang |
+| Haskell | tree-sitter/tree-sitter-haskell | v0.23.1 | MIT | hs |
+| HCL | tree-sitter-grammars/tree-sitter-hcl | v1.2.0 | Apache-2.0 | terraform, tf |
+| HTML | tree-sitter/tree-sitter-html | v0.23.2 | MIT | htm |
+| Java | tree-sitter/tree-sitter-java | v0.23.5 | MIT | |
+| JavaScript | tree-sitter/tree-sitter-javascript | v0.23.1 | MIT | js, jsx, mjs, cjs |
+| JSON | tree-sitter/tree-sitter-json | v0.24.8 | MIT | |
+| Kotlin | tree-sitter-grammars/tree-sitter-kotlin | v1.1.0 | MIT | kt |
+| Lua | tree-sitter-grammars/tree-sitter-lua | v0.4.1 | MIT | |
+| Makefile | tree-sitter-grammars/tree-sitter-make | v1.1.1 | MIT | make |
+| Markdown | tree-sitter-grammars/tree-sitter-markdown | v0.5.2 | MIT | md |
+| OCaml | tree-sitter/tree-sitter-ocaml | v0.24.2 | MIT | ml |
+| PHP | tree-sitter/tree-sitter-php | v0.24.2 | MIT | |
+| Python | tree-sitter/tree-sitter-python | v0.23.6 | MIT | py |
+| R | r-lib/tree-sitter-r | v1.2.0 | MIT | |
+| Ruby | tree-sitter/tree-sitter-ruby | v0.23.1 | MIT | rb |
+| Rust | tree-sitter/tree-sitter-rust | v0.24.0 | MIT | rs |
+| Scala | tree-sitter/tree-sitter-scala | v0.24.0 | MIT | |
+| Swift | alex-pinkus/tree-sitter-swift | 0.7.1 | MIT | |
+| TOML | tree-sitter-grammars/tree-sitter-toml | v0.7.0 | MIT | |
+| TSX | tree-sitter/tree-sitter-typescript | v0.23.2 | MIT | |
+| TypeScript | tree-sitter/tree-sitter-typescript | v0.23.2 | MIT | ts |
+| XML | tree-sitter-grammars/tree-sitter-xml | v0.7.0 | MIT | |
+| YAML | tree-sitter-grammars/tree-sitter-yaml | v0.7.2 | MIT | yml |
+| Zig | tree-sitter-grammars/tree-sitter-zig | v1.1.2 | MIT | |
 
 ## Building Locally
 


### PR DESCRIPTION
## Summary
- Add TOML, Fortran, Clojure to supported languages table
- Update count from 36 → 39
- Alphabetize the table for easier scanning

## Test plan
- [ ] Table renders correctly on GitHub