### PR TITLE
ci: add path filtering to skip builds on docs-only changes

### DIFF
--- a/.github/workflows/build-grammars.yml
+++ b/.github/workflows/build-grammars.yml
@@ -12,7 +12,28 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'grammars.json'
+              - 'scripts/**'
+              - 'version.txt'
+              - '.github/workflows/build-grammars.yml'
+
   build:
+    needs: changes
+    if: |
+      needs.changes.outputs.build == 'true' ||
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: macos-14  # Apple Silicon runner (can build universal)
 
     steps:


### PR DESCRIPTION
## Summary
Adds path filtering using `dorny/paths-filter` to skip expensive macOS builds when only documentation changes.

**Build job runs when:**
- `grammars.json` changes (new/updated grammars)
- `scripts/**` changes (build script updates)
- `version.txt` changes (version bump)
- `.github/workflows/build-grammars.yml` changes (workflow updates)
- `workflow_dispatch` (manual trigger)
- Tag push

**Build job skips when:**
- Only `README.md`, `CLAUDE.md`, `LICENSE`, or other docs change

## Test plan
- [x] This PR should trigger the build (workflow file changed)
- [ ] Merge #30 after this - it should skip the build (docs only)