### PR TITLE
[codex] add repo-local codereview agent

### DIFF
--- a/.codereview/agents/grammars/index.yaml
+++ b/.codereview/agents/grammars/index.yaml
@@ -1,0 +1,3 @@
+name: grammars
+description: Reviewer definitions for grammar metadata and release workflows.
+owner: open-cli-collective

--- a/.codereview/agents/grammars/macos-dylib-release/index.yaml
+++ b/.codereview/agents/grammars/macos-dylib-release/index.yaml
@@ -1,0 +1,15 @@
+name: macos-dylib-release
+description: Reviews macOS universal tree-sitter dylib release changes for SwiftMarkdown.
+model_tier: small
+effort: low
+file_globs:
+  - grammars.json
+  - version.txt
+  - README.md
+  - CLAUDE.md
+  - scripts/**
+  - .github/workflows/**
+  - .codereview/**
+applies_when:
+  - Changes affect grammar release metadata, packaging scripts, release automation, or documentation that can impact macOS universal dylib artifacts for SwiftMarkdown.
+needs_full_file_content: false

--- a/.codereview/agents/grammars/macos-dylib-release/prompt.md
+++ b/.codereview/agents/grammars/macos-dylib-release/prompt.md
@@ -1,0 +1,14 @@
+Review only for issues that could break or invalidate the macOS universal tree-sitter dylib release path used by SwiftMarkdown.
+
+Prioritize 0-5 findings. Return no findings when the diff is acceptable. Avoid style feedback unless it hides a release-integrity problem.
+
+Focus on:
+- License compatibility for bundled or redistributed grammar artifacts.
+- `grammars.json` metadata correctness, including tag, SHA, subpath, `requiresGeneration`, and any assumptions about generated parser sources.
+- Scripts and workflows that download, build, package, checksum, size, version, or publish artifacts.
+- macOS universal build behavior: both `arm64` and `x86_64`, merge/package steps, and any architecture-specific gaps.
+- Query copying and packaging completeness.
+- Manifest checksum and size accuracy.
+- Release triggers, version bumps, and artifact naming expected by SwiftMarkdown.
+
+Flag only concrete, user-impacting problems. If behavior is acceptable, return no findings.


### PR DESCRIPTION
## Summary
- add a repo-local `.codereview` reviewer for macOS tree-sitter grammar dylib release integrity
- scope the reviewer to grammar metadata, scripts, workflows, docs, and future `.codereview` changes
- use a tiny `small`/`low` reviewer profile for this narrow repo

## Validation
- `cr --profile codex-rianjs-bot agents list --agents-dir .codereview/agents --json`
